### PR TITLE
feat: add allowSet and whitelist app host from Hantong Chen

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-signatures.js
+++ b/assets/javascripts/discourse/initializers/extend-for-signatures.js
@@ -40,7 +40,18 @@ function attachSignature(api, siteSettings) {
 
         try {
           const hostname = new URL(attrs.user_signature).hostname;
-          if (!["cdn.ldstatic.com", "prompt.iwooji.com", "cdn.linux.do", "linux.do", "linux-do-card.0x1.site"].includes(hostname)) return;
+          const allowSet = new Set([
+            "prompt.iwooji.com",
+            "linux.do",
+            "cdn.linux.do",
+            "cdn.ldstatic.com",
+            // https://github.com/zjkal/linuxdo-card
+            "linux-do-card.0x1.site",
+            // https://github.com/hanyu-dev/greeting-svg
+            "app.acfun.win",
+            "greeting.app.acfun.win",
+          ]);
+          if (!allowSet.has(hostname)) return;
         } catch (e) { return; }
        
         return [


### PR DESCRIPTION
说明：

- app.acfun.win 通用域名（使用 CloudFlare），目前仅部署了 [greeting-svg](https://github.com/hanyu-dev/greeting-svg).
- greeting.app.acfun.win 国内加速域名，专用于 [greeting-svg](https://github.com/hanyu-dev/greeting-svg)。

无任何隐私收集行为（也没有任何计划那么干），代码全部开源，目前含以下三个图例：

![](https://greeting.app.acfun.win/neo?type=linux-do-card)
![](https://greeting.app.acfun.win/neo?type=moe-counter)
![](https://greeting.app.acfun.win/neo&note=Hi%20from%20Index!)

望批准.